### PR TITLE
When maxWait is reached, consume return messages received so far

### DIFF
--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -103,7 +103,7 @@ func TestGetLatestSchemaFails(t *testing.T) {
 	srClient := test.module.Kafka.schemaRegistryClient(&srConfig)
 	assert.Panics(t, func() {
 		schema := test.module.Kafka.getSchema(srClient, &Schema{
-			Subject: "test-subject",
+			Subject: "no-such-subject",
 			Version: 0,
 		})
 		assert.Equal(t, schema, nil)
@@ -125,7 +125,7 @@ func TestGetSchemaFails(t *testing.T) {
 	srClient := test.module.Kafka.schemaRegistryClient(&srConfig)
 	assert.Panics(t, func() {
 		schema := test.module.Kafka.getSchema(srClient, &Schema{
-			Subject: "test-subject",
+			Subject: "no-such-subject",
 			Version: 0,
 		})
 		assert.Equal(t, schema, nil)
@@ -147,7 +147,7 @@ func TestCreateSchemaFails(t *testing.T) {
 	srClient := test.module.Kafka.schemaRegistryClient(&srConfig)
 	assert.Panics(t, func() {
 		schema := test.module.Kafka.getSchema(srClient, &Schema{
-			Subject: "test-subject",
+			Subject: "no-such-subject",
 			Version: 0,
 		})
 		assert.Equal(t, schema, nil)

--- a/serdes_test.go
+++ b/serdes_test.go
@@ -15,10 +15,10 @@ import (
 func TestSerdes(t *testing.T) {
 	test := getTestModuleInstance(t)
 
-	test.createTopic("test-serdes-topic")
-	writer := test.newWriter("test-serdes-topic")
+	test.createTopic()
+	writer := test.newWriter()
 	defer writer.Close()
-	reader := test.newReader("test-serdes-topic")
+	reader := test.newReader()
 	defer reader.Close()
 
 	// Switch to VU code.

--- a/writer_test.go
+++ b/writer_test.go
@@ -14,12 +14,12 @@ import (
 // nolint: funlen
 func TestProduce(t *testing.T) {
 	test := getTestModuleInstance(t)
-	assert.True(t, test.topicExists("test-topic"))
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.writer(&WriterConfig{
 			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
+			Topic:   test.topicName,
 		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
@@ -106,6 +106,7 @@ func TestProduce(t *testing.T) {
 // TestProduceWithoutKey tests the produce function without a key.
 func TestProduceWithoutKey(t *testing.T) {
 	test := getTestModuleInstance(t)
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.writer(&WriterConfig{
@@ -125,7 +126,7 @@ func TestProduceWithoutKey(t *testing.T) {
 							Data:       "value1",
 							SchemaType: String,
 						}),
-						Topic:  "test-topic",
+						Topic:  test.topicName,
 						Offset: 0,
 						Time:   time.Now(),
 					},
@@ -134,7 +135,7 @@ func TestProduceWithoutKey(t *testing.T) {
 							Data:       "value2",
 							SchemaType: String,
 						}),
-						Topic: "test-topic",
+						Topic: test.topicName,
 					},
 				},
 			})
@@ -153,11 +154,12 @@ func TestProduceWithoutKey(t *testing.T) {
 // TestProducerContextCancelled tests the produce function with a cancelled context.
 func TestProducerContextCancelled(t *testing.T) {
 	test := getTestModuleInstance(t)
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.writer(&WriterConfig{
 			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
+			Topic:   test.topicName,
 		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
@@ -208,11 +210,12 @@ func TestProducerContextCancelled(t *testing.T) {
 // TestProduceJSON tests the produce function with a JSON value.
 func TestProduceJSON(t *testing.T) {
 	test := getTestModuleInstance(t)
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.writer(&WriterConfig{
 			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
+			Topic:   test.topicName,
 		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
@@ -247,7 +250,7 @@ func TestWriterClass(t *testing.T) {
 	test := getTestModuleInstance(t)
 
 	require.NoError(t, test.moveToVUCode())
-	test.createTopic("test-writer-class")
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.writerClass(sobek.ConstructorCall{
@@ -255,7 +258,7 @@ func TestWriterClass(t *testing.T) {
 				test.module.vu.Runtime().ToValue(
 					map[string]interface{}{
 						"brokers": []string{"localhost:9092"},
-						"topic":   "test-writer-class",
+						"topic":   test.topicName,
 					},
 				),
 			},


### PR DESCRIPTION
The previous behavior, to panic on deadline is problematic, since there are a number of scenarios where you simply do not know how many messages there are to consume or when they are produced. For example, a load test may produce messages in bursts with jitter for a burn-in test, to try to provoke i data races in the test subject.

The commit also adds a test to verify that we panic if Close() is called while we are consuming. Given the nature of the problem xk6-kafka is trying to solve, this sounds like an errar condition.